### PR TITLE
prośba o sprawdzenie

### DIFF
--- a/src/main/java/wojtek/arabia/gateway/controller/GatewayController.java
+++ b/src/main/java/wojtek/arabia/gateway/controller/GatewayController.java
@@ -23,7 +23,6 @@ public class GatewayController {
         this.requestAndResponseCreator = requestAndResponseCreator;
     }
 
-
     @GetMapping("/test")
     public ResponseEntity<Void> testingTesting() {
         GatewayUserRegistrationRequest request = requestAndResponseCreator.getRequest();
@@ -40,9 +39,6 @@ public class GatewayController {
 
         return ResponseEntity.internalServerError().build();
     }
-
-
-
 
     @PostMapping(value = "/v1/users/registration")
     public ResponseEntity<Void> registerUser(@RequestBody ClientRegistrationRequest request) {

--- a/src/main/java/wojtek/arabia/gateway/outbound/GatewayUserRegistrationRequest.java
+++ b/src/main/java/wojtek/arabia/gateway/outbound/GatewayUserRegistrationRequest.java
@@ -1,5 +1,7 @@
 package wojtek.arabia.gateway.outbound;
 
+import java.util.Objects;
+
 public class GatewayUserRegistrationRequest {
     private String phoneNumber;
 
@@ -9,5 +11,18 @@ public class GatewayUserRegistrationRequest {
 
     public void setPhoneNumber(String phoneNumber) {
         this.phoneNumber = phoneNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GatewayUserRegistrationRequest that = (GatewayUserRegistrationRequest) o;
+        return Objects.equals(phoneNumber, that.phoneNumber);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(phoneNumber);
     }
 }

--- a/src/main/java/wojtek/arabia/gateway/outbound/GatewayUserVerificationRequest.java
+++ b/src/main/java/wojtek/arabia/gateway/outbound/GatewayUserVerificationRequest.java
@@ -1,5 +1,7 @@
 package wojtek.arabia.gateway.outbound;
 
+import java.util.Objects;
+
 public class GatewayUserVerificationRequest {
 
     private String phoneNumber;
@@ -20,5 +22,18 @@ public class GatewayUserVerificationRequest {
 
     public void setOtp(String otp) {
         this.otp = otp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GatewayUserVerificationRequest that = (GatewayUserVerificationRequest) o;
+        return Objects.equals(phoneNumber, that.phoneNumber) && Objects.equals(otp, that.otp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(phoneNumber, otp);
     }
 }


### PR DESCRIPTION
Wojtek napisał parę testów - kod nie jest clean ale działa - webService jest zamockowany, natomiast używamy prawdziwego requestAndResponseCreator.

Przy pisaniu testów widzę, że nie mamy oczywiście ogarniętych wielu przypadków odpowiedzi z User Catalogu - np kiedy kod otp byłby zły - dlatego nie piszę w tym momencie więcej testów. Natomiast na pewno wyjaśnił mi się kontekst tego testowania - equals() and hashCode() musi być overridowany, żeby webServiceMock działał prawidłowo. Jeśli nie będzie, to response będzie null bo obiekt z wewnątrz testu i ten powstający po wywołaniu mockMvc nie będą "equals".